### PR TITLE
Bugfix/dseat 68 with test persons needs in memory bill repo

### DIFF
--- a/RubeesEat.IntegrationTests/CreateTestDb.sql
+++ b/RubeesEat.IntegrationTests/CreateTestDb.sql
@@ -34,6 +34,8 @@ INSERT INTO Persons (PersonID, FirstName, LastName)
 VALUES ('544FEBD0-05F8-471A-BAFC-CA7135538031', 'Lilli', 'Grubber');
 INSERT INTO Persons (PersonID, FirstName, LastName)
 VALUES ('7DBF157B-CBFF-43CE-BFDD-B367611BB1A5', 'Mich', 'Ludwig');
+INSERT INTO Persons (PersonID, FirstName, LastName)
+VALUES ('8e3edf3b-7dcd-4815-bf16-4bc9b9d6dd3b', 'No', 'Bills');
 
 INSERT INTO Bills(BillID, Description, Date)
 VALUES ('91CD57E6-418E-4628-82CC-09D471153CF6', 'Mittagessen auf Patrick sein Nacken', '2024-09-09 10:34:09');

--- a/RubeesEat.IntegrationTests/DB/DbBillRepositoryTest.cs
+++ b/RubeesEat.IntegrationTests/DB/DbBillRepositoryTest.cs
@@ -83,6 +83,14 @@ public class DbBillRepositoryTest : DatabaseIntegrationTestBase
     }
     
     [Test]
+    public void GetBalanceWhenNoBills_ReturnsBalanceOfUser()
+    {
+        var user = _dbPersonRepository.GetById(Guid.Parse("8e3edf3b-7dcd-4815-bf16-4bc9b9d6dd3b"));
+        decimal balance = _dbBillRepository.GetBalance(user);
+        Assert.That(balance, Is.EqualTo(0m));
+    }
+    
+    [Test]
     public void GetById_ReturnsBalanceOfUser()
     {
         var bill = _dbBillRepository.GetById(Guid.Parse("91CD57E6-418E-4628-82CC-09D471153CF6"));

--- a/RubeesEat.IntegrationTests/TestBases/Selenium/WithTestPersons.cs
+++ b/RubeesEat.IntegrationTests/TestBases/Selenium/WithTestPersons.cs
@@ -23,5 +23,7 @@ public class WithTestPersons : WithoutAuth
         PersonRepository.Add(new Person(Guid.NewGuid(), "Mich", "Ludwig"));
 
         services.Replace(ServiceDescriptor.Singleton<IPersonRepository>(PersonRepository));
+        var billRepository = new InMemoryBillRepository();
+        services.Replace(ServiceDescriptor.Singleton<IBillRepository>(billRepository));
     }
 }

--- a/RubeesEat/Model/DB/DbBillRepository.cs
+++ b/RubeesEat/Model/DB/DbBillRepository.cs
@@ -162,15 +162,14 @@ public class DbBillRepository(IDbConnectionFactory connectionFactory) : IBillRep
 
         connection.Open();
 
-        using var reader = command.ExecuteReader();
-
-        decimal sum = 0;
-        while (reader.Read())
+        var result = command.ExecuteScalar();
+        
+        if (result == DBNull.Value)
         {
-            sum += reader.GetDecimal(0);
+            return 0m;
         }
 
-        return sum;
+        return Convert.ToDecimal(result);
     }
 
     public Bill GetById(Guid guid)


### PR DESCRIPTION
https://re-motion.atlassian.net/jira/software/projects/DSEAT/boards/17?selectedIssue=DSEAT-68

Quick bugfix of the new TestBases. The WithTestPersons was missing an empty InMemoryBillRepo, which caused it to use the DbBillRepo.