### PR TITLE
DSEAT-68 WithTestPersons now has InMemoryBillRepository

### DIFF
--- a/RubeesEat.IntegrationTests/TestBases/Selenium/WithTestPersons.cs
+++ b/RubeesEat.IntegrationTests/TestBases/Selenium/WithTestPersons.cs
@@ -23,5 +23,7 @@ public class WithTestPersons : WithoutAuth
         PersonRepository.Add(new Person(Guid.NewGuid(), "Mich", "Ludwig"));
 
         services.Replace(ServiceDescriptor.Singleton<IPersonRepository>(PersonRepository));
+        var billRepository = new InMemoryBillRepository();
+        services.Replace(ServiceDescriptor.Singleton<IBillRepository>(billRepository));
     }
 }


### PR DESCRIPTION


https://re-motion.atlassian.net/jira/software/projects/DSEAT/boards/17?selectedIssue=DSEAT-68

Quick bugfix of the new TestBases. The WithTestPersons was missing an empty InMemoryBillRepo, which caused it to use the DbBillRepo.
