### PR TITLE
Fixing typo, which prevents to split up the bill

### DIFF
--- a/RubeesEat/wwwroot/js/editableBill.js
+++ b/RubeesEat/wwwroot/js/editableBill.js
@@ -224,7 +224,7 @@ function validate(formName) {
         return;
     }
 
-    if (isNan(totalAmount) || totalAmount <= 0) {
+    if (isNaN(totalAmount) || totalAmount <= 0) {
         document.getElementById("placeForErrorMessage").textContent = totalAmount + " ist ungültig. Bitte eine gültige Zahl für den Gesamtbetrag eingeben.";
         return;
     }


### PR DESCRIPTION
Fixing a typo, which prevents to split up the bill, because `isNan` is not recognized as a function. Changed `isNan` to `isNaN`.